### PR TITLE
Fix an issue with awesome print

### DIFF
--- a/lib/saulabs/gauss/distribution.rb
+++ b/lib/saulabs/gauss/distribution.rb
@@ -131,6 +131,7 @@ module Saulabs
       end
     
       def ==(other)
+        return false unless other.kind_of?(self.class)
         self.mean == other.mean && self.variance == other.variance
       end
   

--- a/spec/saulabs/gauss/distribution_spec.rb
+++ b/spec/saulabs/gauss/distribution_spec.rb
@@ -188,3 +188,16 @@ describe Gauss::Distribution, "#replace" do
   end
   
 end
+
+describe Gauss::Distribution, "#==" do
+  let(:distribution) { Gauss::Distribution.with_deviation(25.0, 8.333333) }
+  
+  it "should be reflexive" do
+    distribution.should == distribution
+  end
+
+  it "should not equal any object of another class" do
+    distribution.should_not == Object.new
+  end
+  
+end


### PR DESCRIPTION
Hi all,

we encountered an issue due to #== not checking for its type and raising NoMethodError (because it's calling #mean on the `other` object).
Here is a small fix adding a type check to #== to avoid this problem.

Specs are included too.
