### PR TITLE
Add bundle exec to Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
   - 1.9.3
-script: "rake spec"
+script: "bundle exec rake spec"


### PR DESCRIPTION
When pushing my previous pull request https://github.com/saulabs/trueskill/pull/10 I saw that Travis CI asks for bundle exec to isolates its gems.

(see my comment on the other PR)
